### PR TITLE
fix typo in help text

### DIFF
--- a/src/main/resources/org/jenkins/ci/plugins/autorefresh/ConfigAutoRefresh/help-refreshRate.html
+++ b/src/main/resources/org/jenkins/ci/plugins/autorefresh/ConfigAutoRefresh/help-refreshRate.html
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <div>
 	<span>The number of seconds to pause between automatic page
-		refreshes, on pages which support automaic page refreshing.</span>
+		refreshes, on pages which support automatic page refreshing.</span>
 </div>


### PR DESCRIPTION
I noticed a typo in the help that shows up on the config page. This isn't important and there will likely never be another release of the plugin anyway. (Since it is simple and self contained). But submitting to the git repo so it is correct if there ever is.
